### PR TITLE
Fix npm install dependency conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@typescript-eslint/parser": "7.18.0",
     "concurrently": "9.1.2",
     "eslint": "8.57.1",
-    "eslint-config-prettier": "10.1.5",
+    "eslint-config-prettier": "9.1.0",
     "eslint-plugin-import": "2.31.0",
     "eslint-plugin-simple-import-sort": "12.1.1",
     "prettier": "3.5.3",


### PR DESCRIPTION
## Why

- `npm install` was failing due to a peer dependency conflict between `eslint-config-prettier` versions
- `@fohte/eslint-config@0.1.0` requires `eslint-config-prettier@^9.0.0` but the project had version `10.1.5`

## What

- Downgrade `eslint-config-prettier` from `10.1.5` to `9.1.0` to resolve the conflict
- `npm install` now completes successfully without errors

🤖 Generated with [Claude Code](https://claude.ai/code)