### PR TITLE
Fix build script to add execute permission to cli.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "vibe": "./dist/cli.js"
   },
   "scripts": {
-    "build": "tsc && echo '#!/usr/bin/env node' | cat - dist/cli.js > temp && mv temp dist/cli.js && chmod +x dist/cli.js",
+    "build": "tsc && node scripts/add-shebang.js dist/cli.js",
     "dev": "tsc --watch",
     "lint": "eslint .",
     "format:eslint": "eslint --fix .",

--- a/scripts/add-shebang.js
+++ b/scripts/add-shebang.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+import fs from 'fs'
+import path from 'path'
+
+const filePath = path.resolve(process.argv[2])
+const shebang = '#!/usr/bin/env node\n'
+
+const content = fs.readFileSync(filePath, 'utf8')
+const contentWithShebang = shebang + content
+
+fs.writeFileSync(filePath, contentWithShebang)
+fs.chmodSync(filePath, 0o755)
+
+console.log(`✅ Added shebang and made ${filePath} executable`)


### PR DESCRIPTION
## Why

- After building with `npm run build`, the generated `dist/cli.js` file lacks execute permissions
- This prevents the CLI from being run directly after `npm link` installation

## What

- The build script now adds execute permission (`chmod +x`) to the compiled CLI file
- Users can run the linked `vibe` command without manual permission fixes

🤖 Generated with [Claude Code](https://claude.ai/code)